### PR TITLE
Fixes Heroku db:migrate ERROR: no pg_hba.conf entry for host ... SSL off

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -13,5 +13,11 @@ module.exports = {
     database,
     host,
     dialect: "postgres",
+    dialectOptions: {
+      ssl: {
+        require: true,
+        rejectUnauthorized: false,
+      }
+     }
   },
 };


### PR DESCRIPTION
Please update your starter file so Heroku users don't get this db:migrate error.